### PR TITLE
Fix #17

### DIFF
--- a/cambrinary/cambrinary.py
+++ b/cambrinary/cambrinary.py
@@ -113,6 +113,10 @@ async def look_up(word, trans, synonym, results):
         logger.error('word {} has no result'.format(word))
 
 
+async def run_coros(coros):
+    await asyncio.gather(*coros)
+
+
 def main():
     args = get_args()
     trans = conf.default_trans_language
@@ -125,14 +129,13 @@ def main():
             exit()
         trans = args.translation
     return_dict = OrderedDict()
-    loop = asyncio.get_event_loop()
-    tasks = []
+    coros = []
     logger.info('start to work...')
     for w in args.word:
         wl = w.lower()
         return_dict[wl] = None  # guarantee the orders
-        tasks.append(look_up(wl, trans, synonym, return_dict))
-    loop.run_until_complete(asyncio.wait(tasks))
+        coros.append(look_up(wl, trans, synonym, return_dict))
+    asyncio.run(run_coros(coros))
 
     # threading.Thread()
     # return_dict = OrderedDict()


### PR DESCRIPTION
Fix #17

- [Official doc](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop) recommends heigher-level `asyncio.run` but not `asyncio.get_event_loop`
- In a general sense, I agree with calling the list `tasks` but `asyncio` has `Task` class, which is a convinient wrapper for coroutine. It is confusing that `tasks` is the list of coroutine. Let's rename it.
- From python 3.11, [`async.wait`](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait) raises error if coroutines are passed directly. While we can use `asyncio.create_task` as below (and the error message says), `asyncio.gather` is straightforward here in my opinion.

```python
async def run_coros(coros):
    tasks = [asyncio.create_task(coro) for coro in coros]
    await asyncio.wait(tasks)
```
Tested Python 3.9.6, Python 3.11.1
