### PR TITLE
FIX for curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 0 and fix for following 302 responses

### DIFF
--- a/cambrinary/cambrinary.py
+++ b/cambrinary/cambrinary.py
@@ -24,7 +24,7 @@ def get_args():
 
 async def load(word, trans):
     url = 'https://dictionary.cambridge.org/dictionary/' + trans + '/' + word
-    cmd = 'curl -k -X GET {}'.format(url)
+    cmd = 'curl -k -A "Mozilla Chrome Safari" -X GET {}'.format(url)
     process = await asyncio.subprocess.create_subprocess_shell(cmd, shell=True, stdout=asyncio.subprocess.PIPE,
                                                                stderr=asyncio.subprocess.PIPE)
     stdout, stderr = await process.communicate()

--- a/cambrinary/cambrinary.py
+++ b/cambrinary/cambrinary.py
@@ -24,7 +24,7 @@ def get_args():
 
 async def load(word, trans):
     url = 'https://dictionary.cambridge.org/dictionary/' + trans + '/' + word
-    cmd = 'curl -k -A "Mozilla Chrome Safari" -X GET {}'.format(url)
+    cmd = 'curl -k --location -A "Mozilla Chrome Safari" -X GET {}'.format(url)
     process = await asyncio.subprocess.create_subprocess_shell(cmd, shell=True, stdout=asyncio.subprocess.PIPE,
                                                                stderr=asyncio.subprocess.PIPE)
     stdout, stderr = await process.communicate()


### PR DESCRIPTION
Hello, not including a User-Agent causes the error bellow to occur.


```python
Traceback (most recent call last):
  File "/home/usia/.local/bin/cambrinary", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/usia/Documents/cambrinary/cambrinary/cambrinary.py", line 138, in main
    asyncio.run(run_coros(coros))
  File "/usr/lib64/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/usia/Documents/cambrinary/cambrinary/cambrinary.py", line 117, in run_coros
    await asyncio.gather(*coros)
  File "/home/usia/Documents/cambrinary/cambrinary/cambrinary.py", line 99, in look_up
    dictionary = get_dictionary(html)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/home/usia/Documents/cambrinary/cambrinary/cambrinary.py", line 82, in get_dictionary
    parsed_html = BeautifulSoup(html, features='html.parser')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/bs4/__init__.py", line 315, in __init__
    elif len(markup) <= 256 and (
         ^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
``` 
```
2024-08-18 00:21:28,261 - /home/usia/Documents/cambrinary/cambrinary/cambrinary.py[line:133] - INFO: start to work...
2024-08-18 00:21:28,262 - /usr/lib64/python3.12/asyncio/selector_events.py[line:64] - DEBUG: Using selector: EpollSelector
2024-08-18 00:21:28,262 - /home/usia/Documents/cambrinary/cambrinary/cambrinary.py[line:97] - INFO: begin to retrieve word: [hello] in english
2024-08-18 00:21:28,440 - /home/usia/Documents/cambrinary/cambrinary/cambrinary.py[line:32] - ERROR: failed to curl -k  -X GET https://dictionary.cambridge.org/dictionary/english/hello
2024-08-18 00:21:28,440 - /home/usia/Documents/cambrinary/cambrinary/cambrinary.py[line:33] - ERROR: subprocess stderr: % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 0
``` 